### PR TITLE
Fix check empty bytes

### DIFF
--- a/varint.py
+++ b/varint.py
@@ -60,6 +60,6 @@ def _read_one(stream):
     raises EOFError if the stream ends while reading bytes.
     """
     c = stream.read(1)
-    if c == '':
+    if c == b'':
         raise EOFError("Unexpected EOF while reading bytes")
     return ord(c)


### PR DESCRIPTION
In python 2 old version works, but in python 3:

    >>> '' == b''
    False